### PR TITLE
Code correctness fixes

### DIFF
--- a/bitmap.cpp
+++ b/bitmap.cpp
@@ -481,7 +481,7 @@ map_done:
 			add_label(strdup(base_name), bmp_num - 1);
 		}
 
-		set_define(img_map, "0", -1, NULL);
+		set_define(img_map, "0", -1, false);
 	}
 	if (base_name)
 		free(base_name);

--- a/directive.cpp
+++ b/directive.cpp
@@ -260,8 +260,8 @@ addinstr_fail:
 					strncpy(temp_filename, skip_whitespace (filename), sizeof (temp_filename));
 				} else {
 					strncpy(temp_filename, temp_path, sizeof (temp_filename));
-					strncat(temp_filename, "/", sizeof (temp_filename));
-					strncat(temp_filename, skip_whitespace (filename), sizeof (temp_filename));
+					strncat(temp_filename, "/", sizeof (temp_filename) - 1);
+					strncat(temp_filename, skip_whitespace (filename), sizeof (temp_filename) - 1);
 				}
 				echo_target = fopen (fix_filename (temp_filename), target_format);
 				if (echo_target == NULL) {
@@ -540,7 +540,7 @@ char *parse_emit_string (const char *ptr, ES_TYPE type, void *echo_target) {
 			{
 				if (echo_target != NULL)
 				{
-					fprintf ((FILE *) echo_target, word);
+					fprintf ((FILE *) echo_target, "%s", word);
 				}
 			}
 			else if (type == ES_FCREATE) {

--- a/storage.cpp
+++ b/storage.cpp
@@ -52,7 +52,7 @@ void write_labels (char *filename) {
 	}
 
 	// Create a header node with an impossible label name
-	hdr_node.name = "#header";
+	hdr_node.name = strdup("#header");
 	
 	label_list.data = &hdr_node;
 	label_list.next = NULL;

--- a/utils.cpp
+++ b/utils.cpp
@@ -50,7 +50,7 @@ char *mystrpbrk (const char * string, const char * control) {
  */
 bool is_end_of_code_line (const char *ptr) {
 	if (ptr == NULL)
-		return NULL;
+		return false;
 
 	return (*ptr == '\0' || *ptr == '\n' || *ptr == '\r' || *ptr == ';' || *ptr == '\\');
 }


### PR DESCRIPTION
A couple classes of correctness fixes reported by Clang's static analyzer.

 * Implicit conversion from pointer to bool
 * `strncat` size parameter too large, may cause buffer overflow
 * `printf` with non-constant format string may cause out-of-bounds reads
 * Use of string literal where non-`const` `char *` expected