### PR TITLE
Changed /usr/bin to /usr/local/bin for install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LD = $(CROSS_COMPILE)ld
 CXXFLAGS+= -DUSE_REUSABLES -DUNIXVER -DUSE_BUILTIN_FCREATE
 LDFLAGS+= -lc -lm
 
-PREFIX ?= /usr/local
+DESTDIR ?= /usr/local
 
 ifdef FORCE_NO_GIT
 	FORCE_NO_GIT = 1
@@ -69,7 +69,7 @@ debian: opt spasm
 		rm -f description-pak
 
 install:
-		cp spasm $(PREFIX)/bin/spasm
+		cp spasm $(DESTDIR)/bin/spasm
 
 clean:
 		rm -f $(OBJ) spasm description-pak spasm-ng*.deb spasm-ng*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LD = $(CROSS_COMPILE)ld
 CXXFLAGS+= -DUSE_REUSABLES -DUNIXVER -DUSE_BUILTIN_FCREATE
 LDFLAGS+= -lc -lm
 
-PREFIX ?= /usr/local 
+PREFIX ?= /usr/local
 
 ifdef FORCE_NO_GIT
 	FORCE_NO_GIT = 1
@@ -28,7 +28,7 @@ export LDFLAGS
 
 .cpp.o:
 		$(CC) $(CXXFLAGS) -c $<
-	 
+
 .cpp:
 		$(CC) $(CXXFLAGS) $< -o $@
 
@@ -58,7 +58,7 @@ tar: opt-static
 		tar czvf spasm-ng_$(VERSION)_binary.tar.gz spasm README.md LICENSE inc/
 
 # This is a fake Debian package builder - it uses checkinstall
-# to make this work.	 
+# to make this work.
 debian: opt spasm
 		echo "SPASM-ng is a z80 assembler with extra features to support development for TI calculators." > description-pak
 		checkinstall --requires "zlib1g, libssl1.0.0, libgmp10" \

--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,11 @@ LD = $(CROSS_COMPILE)ld
 CXXFLAGS+= -DUSE_REUSABLES -DUNIXVER -DUSE_BUILTIN_FCREATE
 LDFLAGS+= -lc -lm
 
+PREFIX ?= /usr/local 
+
 ifdef FORCE_NO_GIT
 	FORCE_NO_GIT = 1
 endif
-
 export FORCE_NO_GIT
 
 VERSION=$$(./version.sh | head -n 1)
@@ -68,7 +69,7 @@ debian: opt spasm
 		rm -f description-pak
 
 install:
-		cp spasm /usr/local/bin/spasm
+		cp spasm $(PREFIX)/bin/spasm
 
 clean:
 		rm -f $(OBJ) spasm description-pak spasm-ng*.deb spasm-ng*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ debian: opt spasm
 		rm -f description-pak
 
 install:
-		cp spasm /usr/bin/spasm
+		cp spasm /usr/local/bin/spasm
 
 clean:
 		rm -f $(OBJ) spasm description-pak spasm-ng*.deb spasm-ng*.tar.gz


### PR DESCRIPTION
Mac OS X 10.11 doesn't allow writing in /usr/* anymore (except in /usr/local/*). Sudo is still needed.
This path is still fine for Linux, so it should be good everywhere.