### PR TITLE
Fixed suffixed jr relative offsets.

### DIFF
--- a/directive.cpp
+++ b/directive.cpp
@@ -580,21 +580,21 @@ char *parse_emit_string (const char *ptr, ES_TYPE type, void *echo_target) {
 #endif
 					case ES_BYTE: 
 					{
-						write_arg(value, ARG_NUM_8, 0);
+						write_arg(value, ARG_NUM_8, 0, 0);
 		                stats_datasize++;
 		                program_counter++;
 		                break;
 					}
 					case ES_WORD:
 					{
-		                write_arg(value, ARG_NUM_16, 0);
+		                write_arg(value, ARG_NUM_16, 0, 0);
 		                stats_datasize+=2;
 		                program_counter+=2;
 		                break;
 					}
 					case ES_LONG:
 					{
-						write_arg(value, ARG_NUM_24, 0);
+						write_arg(value, ARG_NUM_24, 0, 0);
 						stats_datasize+=3;
 						program_counter+=3;
 						break;
@@ -611,21 +611,21 @@ char *parse_emit_string (const char *ptr, ES_TYPE type, void *echo_target) {
 					break;
 				case ES_BYTE: 
 					{
-						add_pass_two_expr(word, ARG_NUM_8, 0);
+						add_pass_two_expr(word, ARG_NUM_8, 0, 0);
 		                stats_datasize++;
 		                program_counter++;
 		                break;
 					}
 				case ES_WORD:
 					{
-		                add_pass_two_expr(word, ARG_NUM_16, 0);
+		                add_pass_two_expr(word, ARG_NUM_16, 0, 0);
 		                stats_datasize+=2;
 		                program_counter+=2;
 		                break;
 					}
 				case ES_LONG:
 					{
-						add_pass_two_expr(word, ARG_NUM_24, 0);
+						add_pass_two_expr(word, ARG_NUM_24, 0, 0);
 						stats_datasize += 3;
 						program_counter += 3;
 						break;

--- a/pass_one.cpp
+++ b/pass_one.cpp
@@ -703,23 +703,23 @@ int write_instruction_data (instr *curr_instr, char **arg_ptrs, char **arg_end_p
 				case '*': //16-bit number
 					if (suffix >= 0 && suffix & SUFFIX_IL) {
 						size++;
-						add_pass_two_expr (arg_text, ARG_NUM_24, 0);
+						add_pass_two_expr (arg_text, ARG_NUM_24, size, 0);
 					}
 					else {
-						add_pass_two_expr (arg_text, ARG_NUM_16, 0);
+						add_pass_two_expr (arg_text, ARG_NUM_16, size, 0);
 					}
 					free (arg_text);
 					break;
 				case '&': //8-bit number
-					add_pass_two_expr (arg_text, ARG_NUM_8, 0);
+					add_pass_two_expr (arg_text, ARG_NUM_8, size, 0);
 					free (arg_text);
 					break;
 				case '%': //8-bit address offset
-					add_pass_two_expr (arg_text, ARG_ADDR_OFFSET, 0);
+					add_pass_two_expr (arg_text, ARG_ADDR_OFFSET, size, 0);
 					free (arg_text);
 					break;
 				case '@': //8-bit IX/IY offset	
-					add_pass_two_expr (arg_text, ARG_IX_IY_OFFSET, 0);
+					add_pass_two_expr (arg_text, ARG_IX_IY_OFFSET, size, 0);
 					free (arg_text);
 					break;
 				case '^': //bit number
@@ -727,7 +727,7 @@ int write_instruction_data (instr *curr_instr, char **arg_ptrs, char **arg_end_p
 					bit_arg_text = arg_text;
 					break;
 				case '#':
-					add_pass_two_expr (arg_text, ARG_RST, 0);
+					add_pass_two_expr (arg_text, ARG_RST, size, 0);
 					free(arg_text);
 					break;
 			}
@@ -737,7 +737,7 @@ int write_instruction_data (instr *curr_instr, char **arg_ptrs, char **arg_end_p
 	//if there's extra data at the end of the instruction, write that too
 	if (curr_instr->has_end_data && (mode & MODE_NORMAL || mode & MODE_LIST)) {
 		if (has_bit_arg)
-			add_pass_two_expr (bit_arg_text, ARG_BIT_NUM, curr_instr->end_data);
+			add_pass_two_expr (bit_arg_text, ARG_BIT_NUM, size, curr_instr->end_data);
 		else
 			write_out (curr_instr->end_data);
 	}

--- a/pass_two.h
+++ b/pass_two.h
@@ -26,6 +26,7 @@ typedef struct tagexpr{
 	arg_type type;
 	char *input_file;
 	bool listing_on;
+	int inst_size;
 	int or_value;
 	struct tagexpr *next;
 } expr_t;
@@ -40,9 +41,9 @@ typedef struct output {
 	struct output *next;
 } output_t;
 
-void add_pass_two_expr (char *expr, arg_type type, int or_value);
+void add_pass_two_expr (char *expr, arg_type type, int inst_size, int or_value);
 void add_pass_two_output (char *expr, output_type type);
 void run_second_pass ();
-void write_arg (int value, arg_type type, int or_value);
+void write_arg (int value, arg_type type, int inst_size, int or_value);
 
 #endif


### PR DESCRIPTION
Currently jr relative offsets are computed from inst_end - 2.  This PR changes this to inst_end - inst_size, correctly handling ez80 suffixes.

This program:

            jr.lil  $

Used to compile to:

    1 00:0000 5B 18 FE -  	jr.lil	$

But now compiles to:

    1 00:0000 5B 18 FD -  	jr.lil	$