### PR TITLE
Fixed stuff to cross compile for windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+ISWIN = $(or $(findstring Windows,$(OS)),$(findstring mingw,$(CROSS_COMPILE)))
 CC = $(CROSS_COMPILE)g++
 LD = $(CROSS_COMPILE)ld
-CXXFLAGS+= -DUSE_REUSABLES -DUNIXVER -DUSE_BUILTIN_FCREATE
-LDFLAGS+= -lc -lm
+STRIP = $(CROSS_COMPILE)strip
+CXXFLAGS+= -DUSE_REUSABLES $(if $(ISWIN),,-DUNIXVER) -DUSE_BUILTIN_FCREATE
+LDFLAGS+= -lm
 
 DESTDIR ?= /usr/local
 
@@ -36,15 +38,19 @@ SRC = main.cpp opcodes.cpp pass_one.cpp pass_two.cpp utils.cpp export.cpp preop.
 expand_buf.cpp hash.cpp list.cpp parser.cpp storage.cpp errors.cpp bitmap.cpp modp_ascii.cpp opcodes_ez80.cpp
 OBJ = $(addsuffix .o, $(basename $(SRC)))
 OBJ_FILES = $(addsuffix .o, $(basename $(notdir $(SRC))))
+EXE = $(if $(ISWIN),spasm.exe,spasm)
 
-spasm: $(OBJ) Makefile
-		$(CC) -o spasm $(OBJ_FILES) $(LDFLAGS)
+$(EXE): $(OBJ) Makefile
+	$(CC) -o $@ $(OBJ_FILES) $(LDFLAGS)
+	$(STRIP) $@
 
 debug: CXXFLAGS+= -g
-debug: spasm
+debug: STRIP= :
+debug: $(EXE)
 
 debugp: CXXFLAGS+= -g -DDEBUG_PRINT
-debugp: spasm
+debugp: STRIP= :
+debugp: $(EXE)
 
 prep-special-build:
 		$(MAKE) clean
@@ -55,17 +61,17 @@ opt: prep-special-build $(OBJ)
 		touch opt
 
 static: LDFLAGS+= -static
-static: spasm
+static: $(EXE)
 		touch static
 
 opt-static: opt static
 
 tar: opt-static
-		tar czvf spasm-ng_$(VERSION)_binary.tar.gz spasm README.md LICENSE inc/
+		tar czvf spasm-ng_$(VERSION)_binary.tar.gz $(EXE) README.md LICENSE inc/
 
 # This is a fake Debian package builder - it uses checkinstall
 # to make this work.
-debian: opt spasm
+debian: opt $(EXE)
 		echo "SPASM-ng is a z80 assembler with extra features to support development for TI calculators." > description-pak
 		checkinstall --requires "zlib1g, libssl1.0.0, libgmp10" \
 			--pkgname="spasm-ng" --pkgversion="$(VERSION_DPKG)" --pkgrelease="1" \
@@ -75,17 +81,17 @@ debian: opt spasm
 		rm -f description-pak
 
 install:
-		cp spasm $(DESTDIR)/bin/spasm
+		cp $(EXE) $(DESTDIR)/bin/$(EXE)
 
-check: spasm
-	$(PYTHON) tests/test-runner.py ./spasm
+check: $(EXE)
+	$(PYTHON) tests/test-runner.py ./$(EXE)
 
 coverage: CXXFLAGS+=-g -O0 --coverage
 coverage: LDFLAGS+=-g -O0 --coverage
 coverage: clean check
 
 clean:
-		rm -f $(OBJ) spasm description-pak spasm-ng*.deb spasm-ng*.tar.gz
+		rm -f $(OBJ) $(EXE) description-pak spasm-ng*.deb spasm-ng*.tar.gz
 		rm -f opt static prep-special-build
 		rm -f *.gcno *.gcda *.gcov
 

--- a/bitmap.cpp
+++ b/bitmap.cpp
@@ -132,9 +132,9 @@ static void handle_bitmap_header(const RECT *r, const BITMAPFILEHEADER *bf, cons
 }
 
 #ifdef _WIN32
-static unsigned int log2(unsigned int value)
+static WORD log2(WORD value)
 {
-	unsigned int l = 0;
+	WORD l = 0;
 	while( (value >> l) > 1 ) ++l;
 	return l;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -19,7 +19,7 @@ void write_file (const unsigned char *, int, const char *);
 extern expr_t *expr_list, *expr_list_tail;
 extern output_t *output_list, *output_list_tail;
 
-#ifdef _WIN32
+#ifdef _WINDOWS
 #ifdef SPASM_NG_ENABLE_COM
 CSPASMModule _AtlModule;
 #endif

--- a/spasm.h
+++ b/spasm.h
@@ -31,7 +31,7 @@ typedef enum {
 	EXIT_FATAL_ERROR = 3
 } EXIT_STATUS;
 
-#ifdef WIN32
+#ifdef _WINDOWS
 #include <windows.h>
 #define NEWLINE "\r\n"
 #define PATH_SEPARATOR '\\'

--- a/stdafx.h
+++ b/stdafx.h
@@ -135,7 +135,11 @@ using namespace ATL;
 
 #define __inout
 
+#ifdef UNIXVER
 typedef unsigned int DWORD;
+#else
+#include <windows.h>
+#endif
 typedef const char *LPCTSTR;
 typedef char *LPSTR, *LPTSTR;
 typedef char TCHAR;
@@ -152,7 +156,9 @@ typedef void *LPVOID;
 #define StringCchPrintf(dest, size, fmt, ...) snprintf(dest, size, fmt, __VA_ARGS__)
 #define StringCchVPrintf(dest, size, fmt, args) vsnprintf(dest, size, fmt, args)
 
+#ifdef UNIXVER
 #define ARRAYSIZE(z) (sizeof(z)/sizeof((z)[0]))
+#endif
 
 #endif
 #endif


### PR DESCRIPTION
This fixes compiling spasm with mingw on linux, so it may fix #45.
Note that you still need to set CROSS_COMPILE, undef UNIXVER, and change the executable to spasm.exe.