### PR TITLE
Build + test with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: make
+    - name: Test
+      run: make check


### PR DESCRIPTION
This could replace travis + appveyor, though right now it just does make/make check on Linux.

An advantage is that it could automatically build binaries that can be downloaded, so we get easy "nightly" binaries.