### PR TITLE
Pass required string for ERR_INVALID_OPERANDS

### DIFF
--- a/pass_one.cpp
+++ b/pass_one.cpp
@@ -341,7 +341,9 @@ char *handle_opcode_or_macro (char *ptr) {
 			if (parse_num(buf, &value)) {
 				cur_buf = value;
 			} else {
-				SetLastSPASMError(SPASM_ERR_INVALID_OPERANDS);
+				char *const name = strndup(name_start, name_end - name_start);
+				SetLastSPASMError(SPASM_ERR_INVALID_OPERANDS, name);
+				free(name);
 			}
 			ptr++;
 		} else if (!strncasecmp (name_start, "clr", name_end - name_start) && *ptr == '(') {

--- a/tests/bugs/issue-71-paren-eof.asm
+++ b/tests/bugs/issue-71-paren-eof.asm
@@ -1,0 +1,3 @@
+; CHECK-NFERR: 104
+; CHECK-NFERR: 110
+b(


### PR DESCRIPTION
When unable to parse an operand to something that appears to be a macro, ensure the required string for the
error message is passed. Failing to do so causes undefined behavior when the error message is formatted, and reliably crashes.

Fixes #71.