### PR TITLE
Remove use of std::binary_function

### DIFF
--- a/hash.h
+++ b/hash.h
@@ -10,7 +10,6 @@ typedef struct {
 } store_t;
 
 struct comparator
-    : public std::binary_function<const char *, const char *, bool>
 {
     bool operator()(const char * _Left, const char *_Right) const
     {


### PR DESCRIPTION
This is unneeded after c++11, and broken from c++17.

Fixes https://github.com/alberthdev/spasm-ng/issues/73