### PR TITLE
Fix for issue #81 so warnings don't crash makefiles.

### DIFF
--- a/errors.cpp
+++ b/errors.cpp
@@ -250,7 +250,7 @@ int CleanupSPASMErrorSession(int nSession)
 		{
 			pPrev->next = pList->next;
 		}
-		if(IsSPASMErrorFatal(lpErr->dwErrorCode)) {
+		if(IsSPASMErrorFatal(lpErr->dwErrorCode) && !lpErr->fIsWarning) {
 			fatalErrorCount++;
 		}
 		FreeErrorInstance(lpErr);


### PR DESCRIPTION
Added a fix to the CleanupSPASMErrorSession function so that it doesn't include warnings when counting the number of fatal errors. This makes it so that warnings don't cause the program to exit which can crash makefiles.